### PR TITLE
Fixing function ordering for AMD loading

### DIFF
--- a/src/Jakefile
+++ b/src/Jakefile
@@ -43,7 +43,7 @@ task('concat', [], function() {
 		fs.closeSync(outFile); 
 	 }
 	 
-	 var withLibs = ownfiles.concat(extrafiles);
+	 var withLibs = extrafiles.concat(ownfiles);
 	 
 	 /*concatFiles(ownfiles, ownFilesMergedFileName);*/
 	 concatFiles(withLibs, withLibsMergedFileName);


### PR DESCRIPTION
For Asynchronous (AMD) loaders like Kickstrap, the fact that the jquery plugin code references functions written later in the code causes the functions to fail. Simply moving those references before the jquery code fixes this.
