### PR TITLE
fix when loading zoomoz before html exists

### DIFF
--- a/src/js/jquery.zoomooz-core.js
+++ b/src/js/jquery.zoomooz-core.js
@@ -169,9 +169,9 @@
                           ".noScroll{overflow:hidden !important;}" +
                           "* {"+transformOrigin+"}";
 
-        document.getElementsByTagName('head')[0].appendChild(style);
 
-        $(document).ready(function() {
+        $(document).ready(function () {
+            document.getElementsByTagName('head')[0].appendChild(style);
             var scrollBarWidth = window.innerWidth - $("body").width();
             style.innerHTML += "body.noScroll,html.noScroll body{margin-right:"+scrollBarWidth+"px;}";
         });

--- a/src/js/jquery.zoomooz-zoomContainer.js
+++ b/src/js/jquery.zoomooz-zoomContainer.js
@@ -41,11 +41,10 @@
     //***  Static setup              ***//
     //**********************************//
 
-    // FIXME: move zoomContainer styling here?
-    //setupCssStyles();
-
     // make all elements with the zoomContainer class zooming containers
-    $(document).ready(function() {
+    $(document).ready(function () {
+        // FIXME: move zoomContainer styling here?
+        //setupCssStyles();
         // this needs to be after the "$.fn.zoomContainer" has been initialized
         $(".zoomContainer").zoomContainer();
     });

--- a/src/js/jquery.zoomooz-zoomTarget.js
+++ b/src/js/jquery.zoomooz-zoomTarget.js
@@ -129,10 +129,9 @@
     //***  Static setup              ***//
     //**********************************//
 
-    setupCssStyles();
-
     // make all elements with the zoomTarget class zooming
-    $(document).ready(function() {
+    $(document).ready(function () {
+        setupCssStyles();
         // this needs to be after the "$.fn.zoomTarget" has been initialized
         $(".zoomTarget").zoomTarget();
     });


### PR DESCRIPTION
If used on a chrome extension with "run_at" : "document_start", there
were a couple spots in the code that assumed the html existed
already. Moved that code to document.ready which already existed nearby in both cases. I have not compiled the root js.