### PR TITLE
affineTransformDecompose more rigidly checks for singularity

### DIFF
--- a/jquery.zoomooz.js
+++ b/jquery.zoomooz.js
@@ -647,7 +647,7 @@ if(!$.zoomooz) {
         var m = matrix.elements();
         var a=m.a, b=m.b, c=m.c, d=m.d, e=m.e, f=m.f;
 
-        if(Math.abs(a*d-b*c)<0.01) {
+        if(Math.abs(a*d-b*c)<0.001) {
             console.log("fail!");
             return;
         }


### PR DESCRIPTION
As noted in https://bugzilla.mozilla.org/show_bug.cgi?id=531344, the matrix needs to be checked for singularity. I think that checking for         `Math.abs(a*d-b*c)<0.01` as a functional approximation is too rigid - i'm working with a project where the window to be transformed is very long and thin, and the `affineTransformDecompose function` regularly throws `"fail!"` at me. No worries if you want to keep it rigid - thought you should know.